### PR TITLE
画面遷移図の提出

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,4 +143,7 @@ URLにアクセスできなかったので現在は稼働していないのか�
 ## ■ 機能の実装方針予定
 ・Discord APIを使用したログイン機能の実装
 
+## 画面遷移図
+https://www.figma.com/file/2tSusw3yavG3JeRrsplpFD/MyDiscordBot?type=whiteboard&t=MDLIsS7nxibzXhZC-0
+
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,6 @@ URLにアクセスできなかったので現在は稼働していないのか�
 ・Discord APIを使用したログイン機能の実装
 
 ## 画面遷移図
-https://www.figma.com/file/gnIzLlFt6AHXvX8c3kQn3o/%E7%84%A1%E9%A1%8C?type=design&node-id=0-1&mode=design&t=R3pqSlaJBrimGVyq-0
+https://www.figma.com/file/gnIzLlFt6AHXvX8c3kQn3o/%E7%84%A1%E9%A1%8C?type=design&node-id=0-1&mode=design&t=8NEOjJyPKLbjuPNU-0
 
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,6 @@ URLにアクセスできなかったので現在は稼働していないのか�
 ・Discord APIを使用したログイン機能の実装
 
 ## 画面遷移図
-https://www.figma.com/file/2tSusw3yavG3JeRrsplpFD/MyDiscordBot?type=whiteboard&t=MDLIsS7nxibzXhZC-0
+https://www.figma.com/file/gnIzLlFt6AHXvX8c3kQn3o/%E7%84%A1%E9%A1%8C?type=design&node-id=0-1&mode=design&t=R3pqSlaJBrimGVyq-0
 
 


### PR DESCRIPTION
お疲れ様です。
49期北島です。

画面遷移図をREADMEに追加しましたのでご確認ください。

***

### 画面遷移図
Figma：https://www.figma.com/file/2tSusw3yavG3JeRrsplpFD/MyDiscordBot?type=whiteboard&t=MDLIsS7nxibzXhZC-0


### READMEに記載した機能

- [x] DiscordのOAuth2.0を利用したログイン機能の実装

- [x] ユーザーごとの学習時間を表示するWebページの作成

- [x] その日の学習時間の合計を表示

- [x] 毎日の学習時間をカレンダー形式で表示

- [x] 毎週の合計がカレンダーの1カラムとして存在(週ごとの学習時間の表示)

- [x] 今までの累積時間の表示

- [x] 日毎の学習記録の表示

- [x] RUNTEQカリキュラムの何を勉強したか

- [x] カリキュラム以外の勉強の場合を考慮し「チーム開発」や「イベント」「書籍」などの選択肢も用意する

- [x] 言語は何を勉強したか

- [x] 円グラフ、もしくはGithubのような横向きの棒グラフで実装（❌ユーザー詳細画面→⭕️ユーザトップ画面に表示） 


### 未ログインでも閲覧または利用できるページ

- [x] トップページ


### メールアドレス・パスワード変更確認項目

- [x] DiscordのOAuth2.0でのみログイン可能のため実装予定なし

***